### PR TITLE
Disabled interaction button when letsgo is active

### DIFF
--- a/Assets/Scripts/DialogueSystem/DialogueManager.cs
+++ b/Assets/Scripts/DialogueSystem/DialogueManager.cs
@@ -200,6 +200,7 @@ public class DialogueManager : MonoBehaviour
         {
             letsGo.SetActive(true);
             Graey.GetComponent<CharacterController>().canInteract = false;
+            interactionButton.interactable = false;
         }
 
         Invoke(functionName, 2.5f);


### PR DESCRIPTION
Stops player from accidentally opening the dialogue box again after activating the mini game transition